### PR TITLE
Fix Assets being downloaded too early

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1668274302
+//version: 1673027205
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -31,7 +31,7 @@ buildscript {
             url 'https://maven.minecraftforge.net'
         }
         maven {
-            // GTNH ForgeGradle Fork
+            // GTNH ForgeGradle and ASM Fork
             name = "GTNH Maven"
             url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
@@ -45,7 +45,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.11'
+        //Overwrite the current ASM version to fix shading newer than java 8 applicatations.
+        classpath 'org.ow2.asm:asm-debug-all-custom:5.0.3'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.13'
     }
 }
 plugins {
@@ -278,7 +280,9 @@ minecraft {
     runDir = 'run'
 
     if (replaceGradleTokenInFile) {
-        replaceIn replaceGradleTokenInFile
+        for (f in replaceGradleTokenInFile.split(',')) {
+            replaceIn f
+        }
         if (gradleTokenModId) {
             replace gradleTokenModId, modId
         }
@@ -315,9 +319,13 @@ if (file('addon.gradle').exists()) {
 apply from: 'repositories.gradle'
 
 configurations {
-    implementation.extendsFrom(shadowImplementation)  // TODO: remove after all uses are refactored
-    implementation.extendsFrom(shadowCompile)
-    implementation.extendsFrom(shadeCompile)
+    // TODO: remove Compile after all uses are refactored to Implementation
+    for (config in [shadowImplementation, shadowCompile, shadeCompile]) {
+        compileClasspath.extendsFrom(config)
+        runtimeClasspath.extendsFrom(config)
+        testCompileClasspath.extendsFrom(config)
+        testRuntimeClasspath.extendsFrom(config)
+    }
 }
 
 repositories {
@@ -330,6 +338,12 @@ repositories {
             name = "GTNH Maven"
             url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
+        if (usesMixinDebug.toBoolean()) {
+            maven {
+                name = "Fabric Maven"
+                url = "https://maven.fabricmc.net/"
+            }
+        }
     }
 }
 
@@ -338,10 +352,14 @@ dependencies {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('org.spongepowered:mixin:0.8.5-GTNH:processor')
+        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.3:processor')
+        if (usesMixinDebug.toBoolean()) {
+            runtimeClasspath('org.jetbrains:intellij-fernflower:1.2.1.16')
+            testRuntimeClasspath('org.jetbrains:intellij-fernflower:1.2.1.16')
+        }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        compile('com.gtnewhorizon:gtnhmixins:2.0.2')
+        compile('com.gtnewhorizon:gtnhmixins:2.1.3')
     }
 }
 
@@ -694,7 +712,7 @@ if (modrinthProjectId.size() != 0 && System.getenv("MODRINTH_TOKEN") != null) {
         }
     }
     if (usesMixins.toBoolean()) {
-        addModrinthDep("required", "version", "gtnhmixins")
+        addModrinthDep("required", "project", "gtnhmixins")
     }
     tasks.modrinth.dependsOn(build)
     tasks.publish.dependsOn(tasks.modrinth)

--- a/src/main/java/glowredman/txloader/CommandTX.java
+++ b/src/main/java/glowredman/txloader/CommandTX.java
@@ -51,6 +51,7 @@ public class CommandTX implements ICommand {
             }
             sender.addChatMessage(
                     getColoredText("Failed saving Config! Look at the Log to find the Cause.", EnumChatFormatting.RED));
+            return;
         }
         if (args[0].equals("add")) {
             if (args.length < 3) {

--- a/src/main/java/glowredman/txloader/RemoteHandler.java
+++ b/src/main/java/glowredman/txloader/RemoteHandler.java
@@ -99,6 +99,7 @@ class RemoteHandler {
             } catch (Exception e) {
                 TXLoaderCore.LOGGER.error("Failed to save asset!", e);
                 failed++;
+                continue;
             }
             TXLoaderCore.LOGGER.debug("Successfully fetched {}", asset.resourceLocation);
             added++;

--- a/src/main/java/glowredman/txloader/TXResourcePack.java
+++ b/src/main/java/glowredman/txloader/TXResourcePack.java
@@ -19,8 +19,6 @@ import org.apache.commons.io.filefilter.DirectoryFileFilter;
 
 public class TXResourcePack implements IResourcePack {
 
-    private static boolean fetchedAssets = false;
-
     private final String name;
     private final Path dir;
 
@@ -42,9 +40,8 @@ public class TXResourcePack implements IResourcePack {
     @SuppressWarnings("rawtypes")
     @Override
     public Set getResourceDomains() {
-        if (!fetchedAssets && TXLoaderCore.isRemoteReachable) {
+        if (TXLoaderCore.isRemoteReachable) {
             RemoteHandler.getAssets();
-            fetchedAssets = true;
         }
 
         File[] subDirs = this.dir.toFile().listFiles((FileFilter) DirectoryFileFilter.DIRECTORY);


### PR DESCRIPTION
Previously, assets were only downloaded on the first call of `TXResourcePack#getResourceDomains`. Adding assets via code in a third-party mod (like BugTorch) is fine in an isolated environment because resources are loaded late enough. In a full pack this is problematic since mods like Better Loading Screen also trigger a resource-reload. This is done far earlier, only assets defined in the TX Loader config are known at this point.
By removing the check if the assets have been downloaded already, assets added later can still be downloaded. This is fine because assets already downloaded are skipped.