### PR TITLE
Add Texture Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1675110695
+//version: 1675173326
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -66,7 +66,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.2'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.3'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -743,6 +743,7 @@ idea {
     module {
         downloadJavadoc = true
         downloadSources = true
+        inheritOutputDirs = true
     }
     project {
         settings {

--- a/src/main/java/glowredman/txloader/Asset.java
+++ b/src/main/java/glowredman/txloader/Asset.java
@@ -1,0 +1,56 @@
+package glowredman.txloader;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+class Asset {
+
+    String resourceLocation;
+    String resourceLocationOverride;
+    boolean forceLoad;
+    String version;
+    Source source;
+    transient boolean addedByMod; // ignored by GSON
+
+    Asset(String resourceLocation, String version, Source source) {
+        this.resourceLocation = resourceLocation;
+        this.version = version;
+        this.source = source;
+    }
+
+    String getResourceLocation() {
+        return this.resourceLocationOverride == null ? this.resourceLocation : this.resourceLocationOverride;
+    }
+
+    File getFile() {
+        File path = this.forceLoad ? TXLoaderCore.forceResourcesDir : TXLoaderCore.resourcesDir;
+        return new File(path, this.getResourceLocation());
+    }
+
+    String getVersion() {
+        return this.version == null ? RemoteHandler.latestRelease : this.version;
+    }
+
+    Source getSource() {
+        return this.source == null ? Source.ASSET : this.source;
+    }
+
+    enum Source {
+
+        ASSET,
+        CLIENT,
+        SERVER;
+
+        static final Iterable<String> NAMES = Arrays.stream(values()).map(Source::name).collect(Collectors.toList());
+
+        static Source get(String name) {
+            try {
+                return valueOf(name);
+            } catch (Exception e) {
+                TXLoaderCore.LOGGER.warn("{} is not a valid source identifier!", name);
+                return ASSET;
+            }
+        }
+    }
+}

--- a/src/main/java/glowredman/txloader/AssetBuilder.java
+++ b/src/main/java/glowredman/txloader/AssetBuilder.java
@@ -1,13 +1,13 @@
 package glowredman.txloader;
 
-import glowredman.txloader.ConfigHandler.Asset;
+import glowredman.txloader.Asset.Source;
 
 public class AssetBuilder {
 
     private final Asset asset;
 
     AssetBuilder(String resourceLocation) {
-        this.asset = new Asset(resourceLocation, RemoteHandler.latestRelease);
+        this.asset = new Asset(resourceLocation, RemoteHandler.latestRelease, Source.ASSET);
         this.asset.addedByMod = true;
     }
 
@@ -43,6 +43,19 @@ public class AssetBuilder {
      */
     public AssetBuilder setVersion(String version) {
         this.asset.version = version;
+        return this;
+    }
+
+    /**
+     * Define this {@link Asset}'s source. Default is {@link Source#ASSET}. {@link Source#CLIENT} and
+     * {@link Source#SERVER} will be cached.
+     * 
+     * @param source
+     * @return This {@link AssetBuilder} object to allow chaining of method calls
+     * @author glowredman
+     */
+    public AssetBuilder setSource(Source source) {
+        this.asset.source = source;
         return this;
     }
 

--- a/src/main/java/glowredman/txloader/ConfigHandler.java
+++ b/src/main/java/glowredman/txloader/ConfigHandler.java
@@ -103,39 +103,4 @@ class ConfigHandler {
             }
         }
     }
-
-    static class Asset {
-
-        String resourceLocation;
-        String resourceLocationOverride;
-        boolean forceLoad = false;
-        String version = RemoteHandler.latestRelease;
-        transient boolean addedByMod = false;
-
-        Asset(String resourceLocation, String version) {
-            this(resourceLocation, version, null, false);
-        }
-
-        Asset(String resourceLocation, String version, String resourceLocationOverride) {
-            this(resourceLocation, version, resourceLocationOverride, false);
-        }
-
-        Asset(String resourceLocation, String version, boolean force) {
-            this(resourceLocation, version, null, force);
-        }
-
-        Asset(String resourceLocation, String version, String resourceLocationOverride, boolean force) {
-            this.resourceLocation = resourceLocation;
-            this.resourceLocationOverride = resourceLocationOverride;
-            this.forceLoad = force;
-            this.version = version;
-        }
-
-        File getFile() {
-            File path = this.forceLoad ? TXLoaderCore.forceResourcesDir : TXLoaderCore.resourcesDir;
-            String resourceLocation = this.resourceLocationOverride == null ? this.resourceLocation
-                    : this.resourceLocationOverride;
-            return new File(path, resourceLocation);
-        }
-    }
 }

--- a/src/main/java/glowredman/txloader/JarHandler.java
+++ b/src/main/java/glowredman/txloader/JarHandler.java
@@ -1,0 +1,71 @@
+package glowredman.txloader;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+class JarHandler {
+
+    static final Map<String, Path> CACHED_CLIENT_JARS = new HashMap<>();
+    static final Map<String, Path> CACHED_SERVER_JARS = new HashMap<>();
+
+    static Path txloaderCache;
+
+    static void indexJars() {
+        String userHome = System.getProperty("user.home");
+        txloaderCache = Paths.get(userHome, "txloader");
+
+        List<Pair<Path, String>> clientLocations = new ArrayList<>();
+        clientLocations.add(Pair.of(txloaderCache, "client.jar"));
+        clientLocations.add(Pair.of(Paths.get(userHome, "AppData", "Roaming", ".minecraft", "versions"), "%s.jar"));
+        clientLocations.add(
+                Pair.of(
+                        Paths.get(userHome, ".gradle", "caches", "forge_gradle", "minecraft_repo", "versions"),
+                        "client.jar"));
+        clientLocations.add(
+                Pair.of(
+                        Paths.get(userHome, ".gradle", "caches", "minecraft", "net", "minecraft", "minecraft"),
+                        "minecraft-%s.jar"));
+        clientLocations.add(
+                Pair.of(Paths.get(userHome, ".gradle", "caches", "retro_futura_gradle", "mc-vanilla"), "client.jar"));
+
+        List<Pair<Path, String>> serverLocations = new ArrayList<>();
+        clientLocations.add(Pair.of(txloaderCache, "server.jar"));
+        serverLocations.add(
+                Pair.of(
+                        Paths.get(userHome, ".gradle", "caches", "forge_gradle", "minecraft_repo", "versions"),
+                        "server.jar"));
+        serverLocations.add(
+                Pair.of(
+                        Paths.get(userHome, ".gradle", "caches", "minecraft", "net", "minecraft", "minecraft_server"),
+                        "minecraft_server-%s.jar"));
+        serverLocations.add(
+                Pair.of(Paths.get(userHome, ".gradle", "caches", "retro_futura_gradle", "mc-vanilla"), "server.jar"));
+
+        for (String version : RemoteHandler.VERSIONS.keySet()) {
+            for (Pair<Path, String> location : clientLocations) {
+                Path jarPath = location.getLeft().resolve(version).resolve(String.format(location.getRight(), version));
+                if (Files.exists(jarPath)) {
+                    CACHED_CLIENT_JARS.put(version, jarPath);
+                    TXLoaderCore.LOGGER.debug("Found CLIENT jar for version {} at {}", version, jarPath);
+                    break;
+                }
+            }
+            for (Pair<Path, String> location : serverLocations) {
+                Path jarPath = location.getLeft().resolve(version).resolve(String.format(location.getRight(), version));
+                if (Files.exists(jarPath)) {
+                    CACHED_SERVER_JARS.put(version, jarPath);
+                    TXLoaderCore.LOGGER.debug("Found SERVER jar for version {} at {}", version, jarPath);
+                    break;
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/glowredman/txloader/RemoteHandler.java
+++ b/src/main/java/glowredman/txloader/RemoteHandler.java
@@ -1,33 +1,38 @@
 package glowredman.txloader;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarFile;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
-import glowredman.txloader.ConfigHandler.Asset;
+import com.google.gson.JsonSyntaxException;
 
+import cpw.mods.fml.common.ProgressManager;
+import cpw.mods.fml.common.ProgressManager.ProgressBar;
+import glowredman.txloader.Asset.Source;
+
+@SuppressWarnings("deprecation")
 class RemoteHandler {
 
     static String latestRelease;
-    static final Map<String, String> VERSIONS = new LinkedHashMap<>();
+    static final Map<String, JVersion> VERSIONS = new LinkedHashMap<>();
 
     static boolean getVersions() {
         JVersionManifest manifest;
 
         try {
-            manifest = TXLoaderCore.GSON.fromJson(
-                    IOUtils.toString(
-                            new URL("https://launchermeta.mojang.com/mc/game/version_manifest.json"),
-                            StandardCharsets.UTF_8),
-                    JVersionManifest.class);
+            manifest = downloadManifest();
         } catch (Exception e) {
             TXLoaderCore.LOGGER.error("Failed to get Minecraft versions!", e);
             return false;
@@ -35,9 +40,7 @@ class RemoteHandler {
 
         latestRelease = manifest.latest.release;
 
-        for (JVersion version : manifest.versions) {
-            VERSIONS.put(version.id, version.url);
-        }
+        manifest.versions.forEach(JVersion::cache);
 
         TXLoaderCore.LOGGER.info("Successfully fetched Minecraft versions.");
 
@@ -45,67 +48,112 @@ class RemoteHandler {
     }
 
     static void getAssets() {
-        Map<String, Map<String, JAsset>> assets = new HashMap<>();
+        final Map<JVersionDetails, Map<String, JAsset>> assets = new HashMap<>();
+        final Map<String, JVersionDetails> versionDetailsCache = new HashMap<>();
+        final ProgressBar bar = ProgressManager.push("Loading Remote Assets", TXLoaderCore.REMOTE_ASSETS.size());
         int added = 0;
         int skipped = 0;
         int failed = 0;
 
         for (Asset asset : TXLoaderCore.REMOTE_ASSETS) {
+            bar.step(asset.getResourceLocation());
             File file = asset.getFile();
             if (file.exists()) {
                 skipped++;
                 continue;
             }
 
-            if (!assets.containsKey(asset.version)) {
-                String url = VERSIONS.get(asset.version);
-                if (url == null) {
-                    failed++;
-                    continue;
-                }
-                try {
-                    String assetsURL = TXLoaderCore.GSON.fromJson(
-                            IOUtils.toString(new URL(url), StandardCharsets.UTF_8),
-                            JVersionDetails.class).assetIndex.url;
-                    assets.put(
-                            asset.version,
-                            TXLoaderCore.GSON.fromJson(
-                                    IOUtils.toString(new URL(assetsURL), StandardCharsets.UTF_8),
-                                    JObjects.class).objects);
-                } catch (Exception e) {
-                    TXLoaderCore.LOGGER.error("Failed to get asset information!", e);
-                    assets.put(asset.version, new HashMap<>()); // don't check this version again...
-                    failed++;
-                    continue;
-                }
-            }
-            JAsset jasset = assets.get(asset.version).get(asset.resourceLocation);
-            if (jasset == null) {
+            String version = asset.getVersion();
+
+            JVersionDetails versionDetails = versionDetailsCache
+                    .computeIfAbsent(version, RemoteHandler::downloadDetails);
+            if (versionDetails == null) {
                 failed++;
                 continue;
             }
 
-            byte[] data;
+            Source source = asset.getSource();
+
+            if (source == Source.ASSET) {
+                JAsset jAsset = assets.computeIfAbsent(versionDetails, JVersionDetails::getAssets)
+                        .get(asset.resourceLocation);
+
+                if (jAsset == null) {
+                    failed++;
+                    continue;
+                }
+
+                try {
+                    jAsset.download(file);
+                } catch (Exception e) {
+                    TXLoaderCore.LOGGER.error("Failed to get asset!", e);
+                    failed++;
+                }
+                continue;
+            }
+
+            // asset from client/server jar:
+            Path jarPath = source == Source.CLIENT ? JarHandler.CACHED_CLIENT_JARS.get(version)
+                    : JarHandler.CACHED_SERVER_JARS.get(version);
+            if (jarPath == null) {
+                if (source == Source.CLIENT) {
+                    try {
+                        jarPath = versionDetails.downloads.client.downloadJar(version, "client.jar");
+                        JarHandler.CACHED_CLIENT_JARS.put(version, jarPath);
+                    } catch (Exception e) {
+                        TXLoaderCore.LOGGER.error("Failed to download client jar and no cached jar was be found", e);
+                        failed++;
+                        continue;
+                    }
+                } else {
+                    try {
+                        jarPath = versionDetails.downloads.server.downloadJar(version, "server.jar");
+                        JarHandler.CACHED_SERVER_JARS.put(version, jarPath);
+                    } catch (Exception e) {
+                        TXLoaderCore.LOGGER.error("Failed to download server jar and no cached jar was be found", e);
+                        failed++;
+                        continue;
+                    }
+                }
+            }
+
             try {
-                data = IOUtils.toByteArray(jasset.getURL());
+                JarFile jarFile = new JarFile(jarPath.toFile());
+                InputStream is = jarFile.getInputStream(jarFile.getJarEntry("assets/" + asset.resourceLocation));
+                FileUtils.copyInputStreamToFile(is, file);
             } catch (Exception e) {
-                TXLoaderCore.LOGGER.error("Failed to get asset!", e);
+                TXLoaderCore.LOGGER.error("Failed to extract asset from jar!", e);
                 failed++;
                 continue;
             }
-            file.getParentFile().mkdirs();
-            try {
-                FileUtils.writeByteArrayToFile(file, data);
-            } catch (Exception e) {
-                TXLoaderCore.LOGGER.error("Failed to save asset!", e);
-                failed++;
-                continue;
-            }
+
             TXLoaderCore.LOGGER.debug("Successfully fetched {}", asset.resourceLocation);
             added++;
         }
         TXLoaderCore.LOGGER.info("Successfully added {} assets. ({} skipped, {} failed)", added, skipped, failed);
+        ProgressManager.pop(bar);
     }
+
+    private static JVersionManifest downloadManifest() throws JsonSyntaxException, IOException {
+        final URL manifestURL = new URL("https://launchermeta.mojang.com/mc/game/version_manifest.json");
+        return TXLoaderCore.GSON
+                .fromJson(IOUtils.toString(manifestURL, StandardCharsets.UTF_8), JVersionManifest.class);
+    }
+
+    private static JVersionDetails downloadDetails(String version) {
+        try {
+            final URL versionURL = new URL(VERSIONS.get(version).url);
+            return TXLoaderCore.GSON
+                    .fromJson(IOUtils.toString(versionURL, StandardCharsets.UTF_8), JVersionDetails.class);
+        } catch (Exception e) {
+            TXLoaderCore.LOGGER.error("Failed to get version details", e);
+            return null;
+        }
+    }
+
+    /*
+     * JSON templates
+     */
 
     private static class JVersionManifest {
 
@@ -122,19 +170,51 @@ class RemoteHandler {
 
         private String id;
         private String url;
+
+        private void cache() {
+            VERSIONS.put(this.id, this);
+        }
     }
 
     private static class JVersionDetails {
 
-        private JAssetIndex assetIndex;
+        private JSourceDetails assetIndex;
+        private JDownloads downloads;
+
+        private Map<String, JAsset> getAssets() {
+            try {
+                final URL assetsURL = new URL(this.assetIndex.url);
+                return TXLoaderCore.GSON
+                        .fromJson(IOUtils.toString(assetsURL, StandardCharsets.UTF_8), JAssetIndex.class).objects;
+            } catch (Exception e) {
+                TXLoaderCore.LOGGER.error("Failed to get asset index", e);
+                // don't check this version again...
+                return new HashMap<>();
+            }
+        }
+    }
+
+    private static class JSourceDetails {
+
+        private String url;
+
+        private Path downloadJar(String version, String fileName) throws IOException {
+            File dir = JarHandler.txloaderCache.resolve(version).toFile();
+            dir.mkdirs();
+            File jar = new File(dir, fileName);
+            TXLoaderCore.LOGGER.info("Downloading {} to {}", this.url, jar);
+            FileUtils.copyURLToFile(new URL(url), jar, 2000, 10000);
+            return jar.toPath();
+        }
+    }
+
+    private static class JDownloads {
+
+        private JSourceDetails client;
+        private JSourceDetails server;
     }
 
     private static class JAssetIndex {
-
-        private String url;
-    }
-
-    private static class JObjects {
 
         private Map<String, JAsset> objects;
     }
@@ -142,6 +222,13 @@ class RemoteHandler {
     private static class JAsset {
 
         private String hash;
+
+        private void download(File file) throws IOException {
+            URL url = this.getURL();
+            file.getParentFile().mkdirs();
+            TXLoaderCore.LOGGER.info("Downloading {} to {}", url, file);
+            FileUtils.copyURLToFile(url, file, 2000, 10000);
+        }
 
         private URL getURL() throws MalformedURLException {
             StringBuilder sb = new StringBuilder(84);

--- a/src/main/java/glowredman/txloader/RemoteHandler.java
+++ b/src/main/java/glowredman/txloader/RemoteHandler.java
@@ -101,7 +101,7 @@ class RemoteHandler {
                         jarPath = versionDetails.downloads.client.downloadJar(version, "client.jar");
                         JarHandler.CACHED_CLIENT_JARS.put(version, jarPath);
                     } catch (Exception e) {
-                        TXLoaderCore.LOGGER.error("Failed to download client jar and no cached jar was be found", e);
+                        TXLoaderCore.LOGGER.error("Failed to download client jar and no cached jar was found", e);
                         failed++;
                         continue;
                     }
@@ -110,7 +110,7 @@ class RemoteHandler {
                         jarPath = versionDetails.downloads.server.downloadJar(version, "server.jar");
                         JarHandler.CACHED_SERVER_JARS.put(version, jarPath);
                     } catch (Exception e) {
-                        TXLoaderCore.LOGGER.error("Failed to download server jar and no cached jar was be found", e);
+                        TXLoaderCore.LOGGER.error("Failed to download server jar and no cached jar was found", e);
                         failed++;
                         continue;
                     }

--- a/src/main/java/glowredman/txloader/TXLoaderCore.java
+++ b/src/main/java/glowredman/txloader/TXLoaderCore.java
@@ -17,7 +17,6 @@ import cpw.mods.fml.relauncher.IFMLLoadingPlugin.MCVersion;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin.Name;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin.SortingIndex;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
-import glowredman.txloader.ConfigHandler.Asset;
 
 @Name("TX Loader Core")
 @TransformerExclusions("glowredman.txloader")
@@ -66,6 +65,7 @@ public class TXLoaderCore implements IFMLLoadingPlugin {
         forceResourcesDir.mkdirs();
 
         isRemoteReachable = RemoteHandler.getVersions();
+        JarHandler.indexJars();
         ConfigHandler.load();
         ConfigHandler.moveRLAssets();
     }


### PR DESCRIPTION
Previously, only files from the asset index ([example](https://piston-meta.mojang.com/v1/packages/f7033757bcb91e11d79f0f31330d680cc787631f/1.19.json) for 1.19) could be downloaded because they are individual files. This mostly includes sound and lang files. Textures however are included in the client jar. Thus, they can't be downloaded individually. To avoid downloading unneccessary files, TX Loader first looks for local copies and caches newly downloaded ones globally.