### PR TITLE
Change the Cache directory location

### DIFF
--- a/src/main/java/glowredman/txloader/JarHandler.java
+++ b/src/main/java/glowredman/txloader/JarHandler.java
@@ -31,7 +31,7 @@ class JarHandler {
                 txloaderCache = Paths.get(userHome, "AppData", "Local", "Temp", "txloader");
             }
         } else if (system.contains("mac")) {
-            txloaderCache = Paths.get(userHome, "Caches", "txloader");
+            txloaderCache = Paths.get(userHome, "Library", "Caches", "txloader");
         } else {
             String xdgCacheHome = System.getenv("XDG_CACHE_HOME");
             if (xdgCacheHome == null) {

--- a/src/main/java/glowredman/txloader/JarHandler.java
+++ b/src/main/java/glowredman/txloader/JarHandler.java
@@ -22,10 +22,13 @@ class JarHandler {
         String system = System.getProperty("os.name").toLowerCase();
         if (system.contains("win")) {
             String temp = System.getenv("TEMP");
-            if (temp == null) {
-                txloaderCache = Paths.get(userHome, "AppData", "Local", "Temp", "txloader");
-            } else {
+            String localAppData = System.getenv("LOCALAPPDATA");
+            if (temp != null) {
                 txloaderCache = Paths.get(temp, "txloader");
+            } else if (localAppData != null) {
+                txloaderCache = Paths.get(localAppData, "Temp", "txloader");
+            } else {
+                txloaderCache = Paths.get(userHome, "AppData", "Local", "Temp", "txloader");
             }
         } else if (system.contains("mac")) {
             txloaderCache = Paths.get(userHome, "Caches", "txloader");

--- a/src/main/java/glowredman/txloader/JarHandler.java
+++ b/src/main/java/glowredman/txloader/JarHandler.java
@@ -19,8 +19,24 @@ class JarHandler {
 
     static void indexJars() {
         String userHome = System.getProperty("user.home");
-        txloaderCache = Paths.get(userHome, "txloader");
-
+        String system = System.getProperty("os.name").toLowerCase();
+        if(system.contains("win")) {
+            String temp = System.getenv("TEMP");
+            if(temp == null){
+                txloaderCache = Paths.get(userHome,"AppData","Local","Temp","txloader");
+            } else {
+                txloaderCache = Paths.get(temp, "txloader");
+            }
+        } else if(system.contains("mac")) {
+            txloaderCache = Paths.get(userHome,"Caches", "txloader");
+        } else {
+            String xdgCacheHome = System.getenv("XDG_CACHE_HOME");
+            if(xdgCacheHome == null){
+                txloaderCache = Paths.get(userHome, ".cache", "txloader");
+            } else {
+                txloaderCache = Paths.get(xdgCacheHome, "txloader");
+            }
+        }
         List<Pair<Path, String>> clientLocations = new ArrayList<>();
         clientLocations.add(Pair.of(txloaderCache, "client.jar"));
         clientLocations.add(Pair.of(Paths.get(userHome, "AppData", "Roaming", ".minecraft", "versions"), "%s.jar"));

--- a/src/main/java/glowredman/txloader/JarHandler.java
+++ b/src/main/java/glowredman/txloader/JarHandler.java
@@ -20,18 +20,18 @@ class JarHandler {
     static void indexJars() {
         String userHome = System.getProperty("user.home");
         String system = System.getProperty("os.name").toLowerCase();
-        if(system.contains("win")) {
+        if (system.contains("win")) {
             String temp = System.getenv("TEMP");
-            if(temp == null){
-                txloaderCache = Paths.get(userHome,"AppData","Local","Temp","txloader");
+            if (temp == null) {
+                txloaderCache = Paths.get(userHome, "AppData", "Local", "Temp", "txloader");
             } else {
                 txloaderCache = Paths.get(temp, "txloader");
             }
-        } else if(system.contains("mac")) {
-            txloaderCache = Paths.get(userHome,"Caches", "txloader");
+        } else if (system.contains("mac")) {
+            txloaderCache = Paths.get(userHome, "Caches", "txloader");
         } else {
             String xdgCacheHome = System.getenv("XDG_CACHE_HOME");
-            if(xdgCacheHome == null){
+            if (xdgCacheHome == null) {
                 txloaderCache = Paths.get(userHome, ".cache", "txloader");
             } else {
                 txloaderCache = Paths.get(xdgCacheHome, "txloader");


### PR DESCRIPTION
Change the Cache directory from a `txloader/` in user’s HOME to a series of OS preferred location,
with `~/.cache/txloader` as the fallback.

Randomly dumped files in HOME is sometimes really annoying for lots of people.