### PR TITLE
Fix crashes when environment variables are wrong

### DIFF
--- a/src/main/java/glowredman/txloader/JarHandler.java
+++ b/src/main/java/glowredman/txloader/JarHandler.java
@@ -1,7 +1,13 @@
 package glowredman.txloader;
 
 import java.io.IOException;
-import java.nio.file.*;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -53,9 +59,9 @@ class JarHandler {
                 txloaderCache = Paths.get(userHome, ".cache", "txloader");
             }
             TXLoaderCore.LOGGER.warn(
-                    "Error occurred while txloader cache path was created: {}. The environment variable TEMP or LOCALAPPDATA could be set incorrectly. Use the default cache location: {}",
-                    e,
-                    txloaderCache);
+                    "An error occurred while the TXLoader cache path was created. The environment variable TEMP or LOCALAPPDATA could be set incorrectly. Using the default cache location: "
+                            + txloaderCache,
+                    e);
         }
         List<Pair<Path, String>> clientLocations = new ArrayList<>();
         clientLocations.add(Pair.of(txloaderCache, "client.jar"));

--- a/src/main/java/glowredman/txloader/JarHandler.java
+++ b/src/main/java/glowredman/txloader/JarHandler.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.base.Stopwatch;
+
 import cpw.mods.fml.relauncher.Side;
 
 class JarHandler {
@@ -30,24 +31,33 @@ class JarHandler {
     static void indexJars() {
         String userHome = System.getProperty("user.home");
         String system = System.getProperty("os.name").toLowerCase();
-        if (system.contains("win")) {
-            String temp = System.getenv("TEMP");
-            String localAppData = System.getenv("LOCALAPPDATA");
-            if (temp != null) {
-                txloaderCache = Paths.get(temp, "txloader");
-            } else if (localAppData != null) {
-                txloaderCache = Paths.get(localAppData, "Temp", "txloader");
+        try {
+            if (system.contains("win")) {
+                String temp = System.getenv("TEMP");
+                String localAppData = System.getenv("LOCALAPPDATA");
+                if (temp != null) {
+                    txloaderCache = Paths.get(temp, "txloader");
+                } else if (localAppData != null) {
+                    txloaderCache = Paths.get(localAppData, "Temp", "txloader");
+                } else {
+                    txloaderCache = Paths.get(userHome, "AppData", "Local", "Temp", "txloader");
+                }
+            } else if (system.contains("mac")) {
+                txloaderCache = Paths.get(userHome, "Library", "Caches", "txloader");
             } else {
-                txloaderCache = Paths.get(userHome, "AppData", "Local", "Temp", "txloader");
+                String xdgCacheHome = System.getenv("XDG_CACHE_HOME");
+                if (xdgCacheHome == null) {
+                    txloaderCache = Paths.get(userHome, ".cache", "txloader");
+                } else {
+                    txloaderCache = Paths.get(xdgCacheHome, "txloader");
+                }
             }
-        } else if (system.contains("mac")) {
-            txloaderCache = Paths.get(userHome, "Library", "Caches", "txloader");
-        } else {
-            String xdgCacheHome = System.getenv("XDG_CACHE_HOME");
-            if (xdgCacheHome == null) {
-                txloaderCache = Paths.get(userHome, ".cache", "txloader");
+        } catch (InvalidPathException e) {
+            TXLoaderCore.LOGGER.debug("Create Error: {}\nUse the default cache location! ", e.getMessage());
+            if (system.contains("win")) {
+                txloaderCache = Paths.get(userHome, "AppData", "Local", "Temp", "txloader");
             } else {
-                txloaderCache = Paths.get(xdgCacheHome, "txloader");
+                txloaderCache = Paths.get(userHome, ".cache", "txloader");
             }
         }
         List<Pair<Path, String>> clientLocations = new ArrayList<>();

--- a/src/main/java/glowredman/txloader/JarHandler.java
+++ b/src/main/java/glowredman/txloader/JarHandler.java
@@ -1,12 +1,7 @@
 package glowredman.txloader;
 
 import java.io.IOException;
-import java.nio.file.FileVisitOption;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
+import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -18,7 +13,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.base.Stopwatch;
-
 import cpw.mods.fml.relauncher.Side;
 
 class JarHandler {
@@ -53,12 +47,15 @@ class JarHandler {
                 }
             }
         } catch (InvalidPathException e) {
-            TXLoaderCore.LOGGER.debug("Create Error: {}\nUse the default cache location! ", e.getMessage());
             if (system.contains("win")) {
                 txloaderCache = Paths.get(userHome, "AppData", "Local", "Temp", "txloader");
             } else {
                 txloaderCache = Paths.get(userHome, ".cache", "txloader");
             }
+            TXLoaderCore.LOGGER.warn(
+                    "Error occurred while txloader cache path was created: {}. The environment variable TEMP or LOCALAPPDATA could be set incorrectly. Use the default cache location: {}",
+                    e,
+                    txloaderCache);
         }
         List<Pair<Path, String>> clientLocations = new ArrayList<>();
         clientLocations.add(Pair.of(txloaderCache, "client.jar"));


### PR DESCRIPTION
When some environment variables are wrong, the game will crash. This is a minor problem and should not crash it
![image](https://github.com/GTNewHorizons/TX-Loader/assets/30284813/73c6f47d-7c45-4514-8133-8b80dcd072cf)
