### PR TITLE
Compatible with ID-based dynamic resources

### DIFF
--- a/src/main/java/glowredman/txloader/TXResourcePack.java
+++ b/src/main/java/glowredman/txloader/TXResourcePack.java
@@ -37,6 +37,10 @@ public class TXResourcePack implements IResourcePack {
 
     @Override
     public boolean resourceExists(ResourceLocation rl) {
+        // Some mods load resources dynamically by id
+        if(rl.getResourcePath().contains(":")) {
+            return false;
+        }
         return Files.exists(this.getResourcePath(rl));
     }
 


### PR DESCRIPTION
When there is a dynamic resource address, the client crashes directly.
This is clearly not what players want to see.