### PR TITLE
Fix Metadata not working outside of the Development Environment

### DIFF
--- a/src/main/java/glowredman/txloader/TXLoaderModContainer.java
+++ b/src/main/java/glowredman/txloader/TXLoaderModContainer.java
@@ -1,6 +1,7 @@
 package glowredman.txloader;
 
 import java.io.File;
+import java.util.jar.JarFile;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -9,6 +10,7 @@ import cpw.mods.fml.common.DummyModContainer;
 import cpw.mods.fml.common.LoadController;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.MetadataCollection;
+import cpw.mods.fml.common.ModMetadata;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.versioning.VersionParser;
@@ -18,9 +20,22 @@ import glowredman.txloader.progress.ProgressBarProxy;
 public class TXLoaderModContainer extends DummyModContainer {
 
     public TXLoaderModContainer() {
-        super(
-                MetadataCollection.from(TXLoaderModContainer.class.getResourceAsStream("/mcmod.info"), "TX Loader")
-                        .getMetadataForId("txloader", null));
+        super(getModMetadata());
+    }
+
+    private static ModMetadata getModMetadata() {
+        try (JarFile jar = new JarFile(TXLoaderCore.modFile)) {
+            return MetadataCollection.from(jar.getInputStream(jar.getEntry("mcmod.info")), "TX Loader")
+                    .getMetadataForId("txloader", null);
+        } catch (Exception e) {
+            TXLoaderCore.LOGGER.warn("Failed to get mod metadata", e);
+        }
+        ModMetadata fallback = new ModMetadata();
+        fallback.description = "This is a fallback description! Something went wrong while getting this mod's metadata. Refer to the log and report this issue to the mod's author!";
+        fallback.modId = "txloader";
+        fallback.name = "TX Loader";
+        fallback.version = "0.0-FALLBACK";
+        return fallback;
     }
 
     @Override

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,7 +1,6 @@
 {
 	"modListVersion": 2,
 	"modList": [{
-		"__comment": "",
 		"modid": "${modId}",
 		"name": "${modName}",
 		"description": "Loads official/custom assets",


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/TX-Loader/pull/15#issuecomment-2697518683. The problem was: `TXLoaderModContainer.class.getResourceAsStream("/mcmod.info")` returned *some* mcmod.info file (in my case from GTNHLib). In this file the metadata for "txloader" can obviously not be found.