### PR TITLE
Inject non-force Resources later // Use Java's NIO

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -151,7 +151,7 @@ modrinthProjectId = eh8us8FY
 #       type can be one of [project, version],
 #       and the name is the Modrinth project or version slug/id of the other mod.
 # Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
-# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+# Note: UniMixins is automatically set as a required dependency if usesMixins = true.
 modrinthRelations =
 
 # Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.38'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.43'
 }
 
 

--- a/src/main/java/glowredman/txloader/Asset.java
+++ b/src/main/java/glowredman/txloader/Asset.java
@@ -1,6 +1,6 @@
 package glowredman.txloader;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -23,9 +23,9 @@ public class Asset {
         return this.resourceLocationOverride == null ? this.resourceLocation : this.resourceLocationOverride;
     }
 
-    File getFile() {
-        File path = this.forceLoad ? TXLoaderCore.forceResourcesDir : TXLoaderCore.resourcesDir;
-        return new File(path, this.getResourceLocation());
+    Path getPath() {
+        Path path = this.forceLoad ? TXLoaderCore.forceResourcesDir : TXLoaderCore.resourcesDir;
+        return path.resolve(this.getResourceLocation());
     }
 
     String getVersion() {

--- a/src/main/java/glowredman/txloader/ConfigHandler.java
+++ b/src/main/java/glowredman/txloader/ConfigHandler.java
@@ -1,39 +1,39 @@
 package glowredman.txloader;
 
-import java.io.File;
+import java.io.BufferedReader;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.apache.commons.io.FileUtils;
+import java.util.stream.Stream;
 
 import com.google.common.reflect.TypeToken;
 
 class ConfigHandler {
 
-    private static File configFile;
+    private static Path configFile;
     private static final Type TYPE = new TypeToken<List<Asset>>() {
 
         private static final long serialVersionUID = 1L;
     }.getType();
 
     static void load() {
-        configFile = new File(TXLoaderCore.configDir, "config.json");
+        configFile = TXLoaderCore.configDir.resolve("config.json");
 
-        if (!configFile.exists()) {
+        if (Files.notExists(configFile)) {
             try {
-                FileUtils.write(configFile, TXLoaderCore.GSON.toJson(new ArrayList<>()), StandardCharsets.UTF_8);
+                Files.write(configFile, TXLoaderCore.GSON.toJson(new ArrayList<>()).getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 TXLoaderCore.LOGGER.error("Failed to create config file!", e);
             }
             return;
         }
 
-        try {
-            TXLoaderCore.REMOTE_ASSETS.addAll(
-                    TXLoaderCore.GSON.fromJson(FileUtils.readFileToString(configFile, StandardCharsets.UTF_8), TYPE));
+        try (BufferedReader reader = Files.newBufferedReader(configFile, StandardCharsets.UTF_8)) {
+            TXLoaderCore.REMOTE_ASSETS.addAll(TXLoaderCore.GSON.fromJson(reader, TYPE));
         } catch (Exception e) {
             TXLoaderCore.LOGGER.error("Failed to read config file!", e);
             return;
@@ -44,13 +44,12 @@ class ConfigHandler {
 
     static boolean save() {
         try {
-            FileUtils.write(
+            Files.write(
                     configFile,
                     TXLoaderCore.GSON.toJson(
                             TXLoaderCore.REMOTE_ASSETS.parallelStream().filter(a -> !a.addedByMod)
                                     .collect(Collectors.toList()),
-                            TYPE),
-                    StandardCharsets.UTF_8);
+                            TYPE).getBytes(StandardCharsets.UTF_8));
             return true;
         } catch (Exception e) {
             TXLoaderCore.LOGGER.error("Failed saving config!", e);
@@ -59,45 +58,59 @@ class ConfigHandler {
     }
 
     static void moveRLAssets() {
-        File resources = new File(TXLoaderCore.mcLocation, "resources");
-        File oresources = new File(TXLoaderCore.mcLocation, "oresources");
+        Path resources = TXLoaderCore.mcLocation.resolve("resources");
+        Path oresources = TXLoaderCore.mcLocation.resolve("oresources");
 
-        if (resources.exists()) {
+        if (Files.exists(resources)) {
             TXLoaderCore.LOGGER.info("Attempting to move assets from ./resources/ to ./config/txloader/load/ ...");
 
-            for (File f : resources.listFiles()) {
-                try {
-                    FileUtils.moveToDirectory(f, TXLoaderCore.resourcesDir, false);
-                    TXLoaderCore.LOGGER.debug("Successfully moved {} to ./config/txloader/load/", f.getName());
-                } catch (Exception e) {
-                    TXLoaderCore.LOGGER.warn("Failed to move {} to ./config/txloader/load/", f.getName(), e);
-                }
-            }
+            try (Stream<Path> files = Files.list(resources).filter(Files::isRegularFile)) {
+                files.forEach(p -> {
+                    Path target = resources.relativize(p);
+                    try {
+                        Files.move(p, TXLoaderCore.resourcesDir.resolve(target));
+                        TXLoaderCore.LOGGER
+                                .debug("Successfully moved {} to ./config/txloader/load/", target.getFileName());
+                    } catch (Exception e) {
+                        TXLoaderCore.LOGGER
+                                .warn("Failed to move {} to ./config/txloader/load/", target.getFileName(), e);
+                    }
+                });
 
-            try {
-                resources.delete();
+                try {
+                    Files.delete(resources);
+                } catch (Exception e) {
+                    TXLoaderCore.LOGGER.warn("Failed to delete ./resources/", e);
+                }
             } catch (Exception e) {
-                TXLoaderCore.LOGGER.warn("Failed to delete ./resources/", e);
+                TXLoaderCore.LOGGER.warn("Failed to iterate over files in {}", resources, e);
             }
         }
 
-        if (oresources.exists()) {
+        if (Files.exists(oresources)) {
             TXLoaderCore.LOGGER
                     .info("Attempting to move assets from ./oresources/ to ./config/txloader/forceload/ ...");
 
-            for (File f : oresources.listFiles()) {
-                try {
-                    FileUtils.moveToDirectory(f, TXLoaderCore.forceResourcesDir, false);
-                    TXLoaderCore.LOGGER.debug("Successfully moved {} to ./config/txloader/forceload/", f.getName());
-                } catch (Exception e) {
-                    TXLoaderCore.LOGGER.warn("Failed to move {} to ./config/txloader/forceload/", f.getName(), e);
-                }
-            }
+            try (Stream<Path> files = Files.list(oresources).filter(Files::isRegularFile)) {
+                files.forEach(p -> {
+                    Path target = oresources.relativize(p);
+                    try {
+                        Files.move(p, TXLoaderCore.forceResourcesDir.resolve(target));
+                        TXLoaderCore.LOGGER
+                                .debug("Successfully moved {} to ./config/txloader/forceload/", target.getFileName());
+                    } catch (Exception e) {
+                        TXLoaderCore.LOGGER
+                                .warn("Failed to move {} to ./config/txloader/forceload/", target.getFileName(), e);
+                    }
+                });
 
-            try {
-                oresources.delete();
+                try {
+                    Files.delete(oresources);
+                } catch (Exception e) {
+                    TXLoaderCore.LOGGER.warn("Failed to delete ./oresources/", e);
+                }
             } catch (Exception e) {
-                TXLoaderCore.LOGGER.warn("Failed to delete ./oresources/", e);
+                TXLoaderCore.LOGGER.warn("Failed to iterate over files in {}", resources, e);
             }
         }
     }

--- a/src/main/java/glowredman/txloader/MinecraftClassTransformer.java
+++ b/src/main/java/glowredman/txloader/MinecraftClassTransformer.java
@@ -39,7 +39,7 @@ public class MinecraftClassTransformer implements IClassTransformer {
                                 new MethodInsnNode(
                                         Opcodes.INVOKESTATIC,
                                         "glowredman/txloader/MinecraftHook",
-                                        "insertForcePack",
+                                        "insertPacks",
                                         "(Ljava/util/List;)Ljava/util/List;",
                                         false));
                         success = true;

--- a/src/main/java/glowredman/txloader/MinecraftHook.java
+++ b/src/main/java/glowredman/txloader/MinecraftHook.java
@@ -2,13 +2,26 @@ package glowredman.txloader;
 
 import java.util.List;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.IResourcePack;
+import net.minecraft.client.resources.ResourcePackRepository.Entry;
 
 @SuppressWarnings("unused")
 public class MinecraftHook {
 
-    public static List<IResourcePack> insertForcePack(List<IResourcePack> resourcePackList) {
-        resourcePackList.add(new TXResourcePack.Force());
+    public static List<IResourcePack> insertPacks(List<IResourcePack> resourcePackList) {
+        List<Entry> assignedPacks = Minecraft.getMinecraft().getResourcePackRepository().getRepositoryEntries();
+        IResourcePack pack = new TXResourcePack("TX Loader Resources", TXLoaderCore.resourcesDir);
+
+        if (assignedPacks.isEmpty()) {
+            resourcePackList.add(pack);
+        } else {
+            // inject before user assigned resource packs
+            int index = resourcePackList.indexOf(assignedPacks.get(0).getResourcePack());
+            resourcePackList.add(index, pack);
+        }
+
+        resourcePackList.add(new TXResourcePack("TX Loader Forced Resources", TXLoaderCore.forceResourcesDir));
         return resourcePackList;
     }
 }

--- a/src/main/java/glowredman/txloader/RemoteHandler.java
+++ b/src/main/java/glowredman/txloader/RemoteHandler.java
@@ -1,11 +1,12 @@
 package glowredman.txloader;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -13,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.jar.JarFile;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
 import com.google.gson.JsonSyntaxException;
@@ -56,8 +56,8 @@ class RemoteHandler {
 
         for (Asset asset : TXLoaderCore.REMOTE_ASSETS) {
             bar.step(asset.getResourceLocation());
-            File file = asset.getFile();
-            if (file.exists()) {
+            Path path = asset.getPath();
+            if (Files.exists(path)) {
                 skipped++;
                 continue;
             }
@@ -83,7 +83,7 @@ class RemoteHandler {
                 }
 
                 try {
-                    jAsset.download(file);
+                    jAsset.download(path);
                 } catch (Exception e) {
                     TXLoaderCore.LOGGER.error("Failed to get asset! Path: {}", asset.resourceLocation, e);
                     failed++;
@@ -116,9 +116,9 @@ class RemoteHandler {
                 }
             }
 
-            try (JarFile jarFile = new JarFile(jarPath.toFile())) {
-                InputStream is = jarFile.getInputStream(jarFile.getJarEntry("assets/" + asset.resourceLocation));
-                FileUtils.copyInputStreamToFile(is, file);
+            try (JarFile jarFile = new JarFile(jarPath.toFile());
+                    InputStream is = jarFile.getInputStream(jarFile.getJarEntry("assets/" + asset.resourceLocation))) {
+                Files.copy(is, path);
             } catch (Exception e) {
                 TXLoaderCore.LOGGER.error("Failed to extract asset from jar! Path: {}", asset.resourceLocation, e);
                 failed++;
@@ -197,12 +197,17 @@ class RemoteHandler {
         private String url;
 
         private Path downloadJar(String version, String fileName) throws IOException {
-            File dir = JarHandler.txloaderCache.resolve(version).toFile();
-            dir.mkdirs();
-            File jar = new File(dir, fileName);
+            Path dir = JarHandler.txloaderCache.resolve(version);
+            Files.createDirectories(dir);
+            Path jar = dir.resolve(fileName);
             TXLoaderCore.LOGGER.info("Downloading {} to {}", this.url, jar);
-            FileUtils.copyURLToFile(new URL(url), jar, 2000, 10000);
-            return jar.toPath();
+            URLConnection connection = new URL(this.url).openConnection();
+            connection.setConnectTimeout(2000);
+            connection.setReadTimeout(10000);
+            try (InputStream is = connection.getInputStream()) {
+                Files.copy(is, jar);
+            }
+            return jar;
         }
     }
 
@@ -221,11 +226,16 @@ class RemoteHandler {
 
         private String hash;
 
-        private void download(File file) throws IOException {
+        private void download(Path path) throws IOException {
             URL url = this.getURL();
-            file.getParentFile().mkdirs();
-            TXLoaderCore.LOGGER.info("Downloading {} to {}", url, file);
-            FileUtils.copyURLToFile(url, file, 2000, 10000);
+            Files.createDirectories(path.getParent());
+            TXLoaderCore.LOGGER.info("Downloading {} to {}", url, path);
+            URLConnection connection = url.openConnection();
+            connection.setConnectTimeout(2000);
+            connection.setReadTimeout(10000);
+            try (InputStream is = connection.getInputStream()) {
+                Files.copy(is, path);
+            }
         }
 
         private URL getURL() throws MalformedURLException {

--- a/src/main/java/glowredman/txloader/ServerLangHelper.java
+++ b/src/main/java/glowredman/txloader/ServerLangHelper.java
@@ -1,29 +1,31 @@
 package glowredman.txloader;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import net.minecraft.util.StringTranslate;
 
 class ServerLangHelper {
 
     static void load() {
-        for (File modDir : TXLoaderCore.resourcesDir.listFiles(File::isDirectory)) {
-            inject(modDir);
-        }
-        for (File modDir : TXLoaderCore.forceResourcesDir.listFiles(File::isDirectory)) {
-            inject(modDir);
+        try (Stream<Path> dirs = Files.list(TXLoaderCore.resourcesDir).filter(Files::isDirectory);
+                Stream<Path> forcedDirs = Files.list(TXLoaderCore.forceResourcesDir).filter(Files::isDirectory)) {
+            dirs.forEach(ServerLangHelper::inject);
+            forcedDirs.forEach(ServerLangHelper::inject);
+        } catch (IOException e) {
+            TXLoaderCore.LOGGER.error("Failed to inject lang files", e);
         }
     }
 
-    private static void inject(File modDir) {
-        File langFile = new File(modDir, "lang" + File.separatorChar + "en_US.lang");
-        if (langFile.exists()) {
+    private static void inject(Path modDir) {
+        Path langFile = modDir.resolve("lang").resolve("en_US.lang");
+        if (Files.exists(langFile)) {
             try {
-                StringTranslate.inject(new FileInputStream(langFile));
-            } catch (FileNotFoundException e) {
-                TXLoaderCore.LOGGER.error("Quantum file detected! It exists and doesn't exist at the same time...", e);
+                StringTranslate.inject(Files.newInputStream(langFile));
+            } catch (IOException e) {
+                TXLoaderCore.LOGGER.error("Failed to create InputStream for {}", modDir, e);
             }
         }
     }

--- a/src/main/java/glowredman/txloader/TXLoaderCore.java
+++ b/src/main/java/glowredman/txloader/TXLoaderCore.java
@@ -1,6 +1,9 @@
 package glowredman.txloader;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,10 +31,10 @@ public class TXLoaderCore implements IFMLLoadingPlugin {
     static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     static final List<Asset> REMOTE_ASSETS = new ArrayList<>();
     static File modFile;
-    static File mcLocation;
-    static File configDir;
-    static File resourcesDir;
-    static File forceResourcesDir;
+    static Path mcLocation;
+    static Path configDir;
+    static Path resourcesDir;
+    static Path forceResourcesDir;
     static boolean isRemoteReachable;
 
     @Override
@@ -58,12 +61,18 @@ public class TXLoaderCore implements IFMLLoadingPlugin {
     @Override
     public void injectData(Map<String, Object> data) {
         modFile = (File) data.get("coremodLocation");
-        mcLocation = (File) data.get("mcLocation");
-        configDir = new File(mcLocation, "config" + File.separator + "txloader");
-        resourcesDir = new File(configDir, "load");
-        resourcesDir.mkdirs();
-        forceResourcesDir = new File(configDir, "forceload");
-        forceResourcesDir.mkdirs();
+        mcLocation = ((File) data.get("mcLocation")).toPath();
+        configDir = mcLocation.resolve("config").resolve("txloader");
+        resourcesDir = configDir.resolve("load");
+        forceResourcesDir = configDir.resolve("forceload");
+
+        try {
+            Files.createDirectories(resourcesDir);
+            Files.createDirectories(forceResourcesDir);
+        } catch (IOException e) {
+            LOGGER.error("Failed to create resource directories!", e);
+            return;
+        }
 
         if (FMLLaunchHandler.side().isServer()) {
             ServerLangHelper.load();

--- a/src/main/java/glowredman/txloader/TXLoaderModContainer.java
+++ b/src/main/java/glowredman/txloader/TXLoaderModContainer.java
@@ -44,11 +44,6 @@ public class TXLoaderModContainer extends DummyModContainer {
     }
 
     @Override
-    public Class<?> getCustomResourcePackClass() {
-        return TXResourcePack.Normal.class;
-    }
-
-    @Override
     public File getSource() {
         return TXLoaderCore.modFile;
     }

--- a/src/main/java/glowredman/txloader/TXResourcePack.java
+++ b/src/main/java/glowredman/txloader/TXResourcePack.java
@@ -1,7 +1,6 @@
 package glowredman.txloader;
 
 import java.awt.image.BufferedImage;
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
@@ -13,8 +12,6 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.imageio.ImageIO;
-
 import net.minecraft.client.resources.IResourcePack;
 import net.minecraft.client.resources.data.IMetadataSection;
 import net.minecraft.client.resources.data.IMetadataSerializer;
@@ -22,14 +19,12 @@ import net.minecraft.util.ResourceLocation;
 
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 
-import cpw.mods.fml.common.ModContainer;
-
 public class TXResourcePack implements IResourcePack {
 
     private final String name;
     private final Path dir;
 
-    private TXResourcePack(String name, Path dir) {
+    public TXResourcePack(String name, Path dir) {
         this.name = name;
         this.dir = dir;
     }
@@ -86,35 +81,5 @@ public class TXResourcePack implements IResourcePack {
 
     private Path getResourcePath(ResourceLocation rl) {
         return this.dir.resolve(rl.getResourceDomain()).resolve(rl.getResourcePath());
-    }
-
-    public static class Normal extends TXResourcePack {
-
-        private final ModContainer modContainer;
-
-        public Normal(ModContainer modContainer) {
-            super("TX Loader Resources", TXLoaderCore.resourcesDir.toPath());
-            this.modContainer = modContainer;
-            TXLoaderCore.resourcesDir.mkdir();
-        }
-
-        @Override
-        public BufferedImage getPackImage() {
-            try {
-                return ImageIO.read(
-                        new BufferedInputStream(
-                                this.getClass().getResourceAsStream(this.modContainer.getMetadata().logoFile)));
-            } catch (Exception e) {
-                return null;
-            }
-        }
-    }
-
-    public static class Force extends TXResourcePack {
-
-        public Force() {
-            super("TX Loader Forced Resources", TXLoaderCore.forceResourcesDir.toPath());
-            TXLoaderCore.forceResourcesDir.mkdir();
-        }
     }
 }

--- a/src/main/java/glowredman/txloader/TXResourcePack.java
+++ b/src/main/java/glowredman/txloader/TXResourcePack.java
@@ -1,8 +1,6 @@
 package glowredman.txloader;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,13 +9,12 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import net.minecraft.client.resources.IResourcePack;
 import net.minecraft.client.resources.data.IMetadataSection;
 import net.minecraft.client.resources.data.IMetadataSerializer;
 import net.minecraft.util.ResourceLocation;
-
-import org.apache.commons.io.filefilter.DirectoryFileFilter;
 
 public class TXResourcePack implements IResourcePack {
 
@@ -56,10 +53,11 @@ public class TXResourcePack implements IResourcePack {
             RemoteHandler.getAssets();
         }
 
-        File[] subDirs = this.dir.toFile().listFiles((FileFilter) DirectoryFileFilter.DIRECTORY);
         Set<String> resourceDomains = new HashSet<>();
-        for (File f : subDirs) {
-            resourceDomains.add(f.getName());
+        try (Stream<Path> dirs = Files.list(this.dir).filter(Files::isDirectory)) {
+            dirs.forEach(p -> resourceDomains.add(p.getFileName().toString()));
+        } catch (Exception e) {
+            TXLoaderCore.LOGGER.error("Failed to get resource domains of directory {}", this.dir, e);
         }
         return resourceDomains;
     }


### PR DESCRIPTION
Currently, the non-forced resources are loaded as if they were TX Loader's mod assets. Due to this mod having a coremod, they are very early in the list:

<img width="1865" height="801" alt="image" src="https://github.com/user-attachments/assets/70a4faf6-5293-4417-9690-71a08526a333" />

This PR changes that. They are now placed immediately before the user-selected resource packs. This means that assets put in `./config/txloader/load/` now override other mod's resources too (previously, one had to use `./config/txloader/forceload/` which had the effect that resources packs could no longer be used for these resources). This especially affects ParaTranz projects.

------------------

The other part of this PR is strictly a code adjustment: All\* uses of `java.io.File` were converted to `java.nio.Path` because it _generally_ performs better.

\* Except for `TXLoaderCore.modFile` because that field is only used in `TXLoaderModContainer.getSource()` were it's immediately returned.