### PR TITLE
Improve performance of TXResourcePack.resourceExists

### DIFF
--- a/src/main/java/glowredman/txloader/TXResourcePack.java
+++ b/src/main/java/glowredman/txloader/TXResourcePack.java
@@ -34,7 +34,7 @@ public class TXResourcePack implements IResourcePack {
     @Override
     public boolean resourceExists(ResourceLocation rl) {
         try {
-            return Files.exists(this.getResourcePath(rl));
+            return getResourcePath(rl).toFile().exists();
         } catch (InvalidPathException e) {
             /*
              * Some mods load resources dynamically by id. (example: java.nio.file.InvalidPathException: Illegal char


### PR DESCRIPTION
For some reason `Files.exists` is super slow compared to `File.exits`

This PR is compatible with the multithreading pr and shouldn't cause any merge issues