### PR TITLE
feat(pack-meta): add ForceLoadMeta and PackMetaReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ TX Loader
 - Provides a directory which acts as any other resource pack (`./config/txloader/load/`)
 - Provides a directory which overrides all other assets with the same resource locations (`./config/txloader/forceload/`)
 - Official assets can be downloaded automatically at startup from the official Mojang servers (Mojang's [Brand and Asset Guidelines](https://www.minecraft.net/en-us/terms#terms-brand_guidelines) are not violated this way). Pack devs can do this via a JSON config (`./config/txloader/config.json`), mod devs can use a builder class via `glowredman.txloader.TXLoaderCore#getAssetBuilder`
+- Resource packs in the `resourcepacks/` folder can auto-enable themselves on first boot via a `txloader` block in their `pack.mcmeta` (see [Force-loading resource packs](#force-loading-resource-packs))
 
 ### Config Format
 
@@ -34,3 +35,27 @@ TX Loader
   }
 ]
 ```
+
+### Force-loading resource packs
+
+A resource pack placed in the `resourcepacks/` folder can ask to be enabled automatically the first time the game boots with that pack present. The pack opts in by adding a `txloader` section to its `pack.mcmeta` (this works for both folder packs and `.zip` packs):
+
+```json
+{
+  "pack": {
+    "pack_format": 1,
+    "description": "My Pack"
+  },
+  "txloader": {
+    "forceLoad": true,
+    "priority": "bottom"
+  }
+}
+```
+
+|Field|Type|Default|Description|
+|:---:|:---:|:---:|:---|
+|`forceLoad`|boolean|`false`|If true, TX Loader enables this pack automatically on the first boot it is detected.|
+|`priority`|String|`"bottom"`|`"top"` places the pack above your other selected packs (it overrides them); `"bottom"` places it below them (your other packs win on conflict).|
+
+The pack is enabled only **once**. TX Loader records which packs it has force-loaded in `./config/txloader/forceloaded.json` (keyed by filename, with the timestamp of first load). After that you can disable the pack in the normal Resource Packs screen and it will stay disabled - it will never force itself back on.

--- a/build.gradle
+++ b/build.gradle
@@ -3,3 +3,8 @@
 plugins {
     id 'com.gtnewhorizons.gtnhconvention'
 }
+
+// GTNHGradle does not call useJUnitPlatform(); required for JUnit 5 test discovery
+tasks.named('test', Test) {
+    useJUnitPlatform()
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,3 +1,6 @@
 dependencies {
     compileOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.7.6-GTNH:dev") { transitive = false }
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.2")
 }

--- a/src/main/java/glowredman/txloader/ForceLoadHandler.java
+++ b/src/main/java/glowredman/txloader/ForceLoadHandler.java
@@ -1,0 +1,51 @@
+package glowredman.txloader;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+class ForceLoadHandler {
+
+    static void run(Path mcLocation, Path configDir) {
+        try {
+            Path packsDir = mcLocation.resolve("resourcepacks");
+            if (!Files.isDirectory(packsDir)) return;
+
+            ForceLoadState state = ForceLoadState.load(configDir.resolve("forceloaded.json"));
+            List<String> top = new ArrayList<>();
+            List<String> bottom = new ArrayList<>();
+            String now = Instant.now().toString();
+
+            try (Stream<Path> packs = Files.list(packsDir)) {
+                for (Path pack : (Iterable<Path>) packs::iterator) {
+                    String name = pack.getFileName().toString();
+                    if (state.contains(name)) continue;
+
+                    Optional<ForceLoadMeta> meta = PackMetaReader.read(pack);
+                    if (!meta.isPresent() || !meta.get().forceLoad()) continue;
+
+                    if (meta.get().priority() == ForceLoadMeta.Priority.TOP) {
+                        top.add(name);
+                    } else {
+                        bottom.add(name);
+                    }
+                    state.record(name, now);
+                    TXLoaderCore.LOGGER.info("Force-loading resource pack {} ({})", name, meta.get().priority());
+                }
+            }
+
+            if (top.isEmpty() && bottom.isEmpty()) return;
+
+            Path options = mcLocation.resolve("options.txt");
+            OptionsEditor.enable(options, bottom, ForceLoadMeta.Priority.BOTTOM);
+            OptionsEditor.enable(options, top, ForceLoadMeta.Priority.TOP);
+            state.save();
+        } catch (Exception e) {
+            TXLoaderCore.LOGGER.error("Force-load handling failed", e);
+        }
+    }
+}

--- a/src/main/java/glowredman/txloader/ForceLoadHandler.java
+++ b/src/main/java/glowredman/txloader/ForceLoadHandler.java
@@ -33,7 +33,6 @@ class ForceLoadHandler {
                     } else {
                         bottom.add(name);
                     }
-                    state.record(name, now);
                     TXLoaderCore.LOGGER.info("Force-loading resource pack {} ({})", name, meta.get().priority());
                 }
             }
@@ -41,9 +40,16 @@ class ForceLoadHandler {
             if (top.isEmpty() && bottom.isEmpty()) return;
 
             Path options = mcLocation.resolve("options.txt");
-            OptionsEditor.enable(options, bottom, ForceLoadMeta.Priority.BOTTOM);
-            OptionsEditor.enable(options, top, ForceLoadMeta.Priority.TOP);
-            state.save();
+            boolean recorded = false;
+            if (OptionsEditor.enable(options, bottom, ForceLoadMeta.Priority.BOTTOM) && !bottom.isEmpty()) {
+                for (String name : bottom) state.record(name, now);
+                recorded = true;
+            }
+            if (OptionsEditor.enable(options, top, ForceLoadMeta.Priority.TOP) && !top.isEmpty()) {
+                for (String name : top) state.record(name, now);
+                recorded = true;
+            }
+            if (recorded) state.save();
         } catch (Exception e) {
             TXLoaderCore.LOGGER.error("Force-load handling failed", e);
         }

--- a/src/main/java/glowredman/txloader/ForceLoadMeta.java
+++ b/src/main/java/glowredman/txloader/ForceLoadMeta.java
@@ -1,0 +1,29 @@
+package glowredman.txloader;
+
+class ForceLoadMeta {
+
+    enum Priority {
+        TOP,
+        BOTTOM;
+
+        static Priority fromString(String s) {
+            return "top".equalsIgnoreCase(s) ? TOP : BOTTOM;
+        }
+    }
+
+    private final boolean forceLoad;
+    private final Priority priority;
+
+    ForceLoadMeta(boolean forceLoad, Priority priority) {
+        this.forceLoad = forceLoad;
+        this.priority = priority;
+    }
+
+    boolean forceLoad() {
+        return forceLoad;
+    }
+
+    Priority priority() {
+        return priority;
+    }
+}

--- a/src/main/java/glowredman/txloader/ForceLoadMeta.java
+++ b/src/main/java/glowredman/txloader/ForceLoadMeta.java
@@ -3,6 +3,7 @@ package glowredman.txloader;
 class ForceLoadMeta {
 
     enum Priority {
+
         TOP,
         BOTTOM;
 

--- a/src/main/java/glowredman/txloader/ForceLoadState.java
+++ b/src/main/java/glowredman/txloader/ForceLoadState.java
@@ -1,0 +1,57 @@
+package glowredman.txloader;
+
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.google.gson.reflect.TypeToken;
+
+class ForceLoadState {
+
+    private static final Type MAP_TYPE = new TypeToken<LinkedHashMap<String, String>>() {}.getType();
+
+    private final Path file;
+    private final Map<String, String> records;
+
+    private ForceLoadState(Path file, Map<String, String> records) {
+        this.file = file;
+        this.records = records;
+    }
+
+    static ForceLoadState load(Path file) {
+        Map<String, String> records = new LinkedHashMap<>();
+        if (Files.isRegularFile(file)) {
+            try (Reader r = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+                Map<String, String> loaded = TXLoaderCore.GSON.fromJson(r, MAP_TYPE);
+                if (loaded != null) records.putAll(loaded);
+            } catch (Exception e) {
+                TXLoaderCore.LOGGER.warn("Failed to read {}, starting fresh", file, e);
+            }
+        }
+        return new ForceLoadState(file, records);
+    }
+
+    boolean contains(String filename) {
+        return records.containsKey(filename);
+    }
+
+    void record(String filename, String isoTimestamp) {
+        records.put(filename, isoTimestamp);
+    }
+
+    void save() {
+        try {
+            if (file.getParent() != null) Files.createDirectories(file.getParent());
+            try (Writer w = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+                TXLoaderCore.GSON.toJson(records, w);
+            }
+        } catch (Exception e) {
+            TXLoaderCore.LOGGER.error("Failed to save {}", file, e);
+        }
+    }
+}

--- a/src/main/java/glowredman/txloader/OptionsEditor.java
+++ b/src/main/java/glowredman/txloader/OptionsEditor.java
@@ -1,0 +1,65 @@
+package glowredman.txloader;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+class OptionsEditor {
+
+    private static final String KEY = "resourcePacks:";
+    // Minecraft writes this line compactly; match that format.
+    private static final Gson COMPACT = new Gson();
+
+    static void enable(Path optionsFile, List<String> names, ForceLoadMeta.Priority placement) {
+        if (names == null || names.isEmpty()) return;
+        try {
+            List<String> lines = Files.isRegularFile(optionsFile)
+                    ? new ArrayList<>(Files.readAllLines(optionsFile, StandardCharsets.UTF_8))
+                    : new ArrayList<>();
+
+            int index = -1;
+            for (int i = 0; i < lines.size(); i++) {
+                if (lines.get(i).startsWith(KEY)) {
+                    index = i;
+                    break;
+                }
+            }
+
+            List<String> packs = index >= 0 ? parse(lines.get(index).substring(KEY.length())) : new ArrayList<>();
+
+            for (String name : names) {
+                if (packs.contains(name)) continue;
+                if (placement == ForceLoadMeta.Priority.TOP) {
+                    packs.add(name);
+                } else {
+                    packs.add(0, name);
+                }
+            }
+
+            String newLine = KEY + COMPACT.toJson(packs);
+            if (index >= 0) {
+                lines.set(index, newLine);
+            } else {
+                lines.add(newLine);
+            }
+
+            Files.write(optionsFile, lines, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            TXLoaderCore.LOGGER.error("Failed to update {}", optionsFile, e);
+        }
+    }
+
+    private static List<String> parse(String json) {
+        try {
+            List<String> parsed = COMPACT.fromJson(json.trim(), new TypeToken<List<String>>() {}.getType());
+            return parsed != null ? new ArrayList<>(parsed) : new ArrayList<>();
+        } catch (Exception e) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/glowredman/txloader/OptionsEditor.java
+++ b/src/main/java/glowredman/txloader/OptionsEditor.java
@@ -15,8 +15,8 @@ class OptionsEditor {
     // Minecraft writes this line compactly; match that format.
     private static final Gson COMPACT = new Gson();
 
-    static void enable(Path optionsFile, List<String> names, ForceLoadMeta.Priority placement) {
-        if (names == null || names.isEmpty()) return;
+    static boolean enable(Path optionsFile, List<String> names, ForceLoadMeta.Priority placement) {
+        if (names == null || names.isEmpty()) return true;
         try {
             List<String> lines = Files.isRegularFile(optionsFile)
                     ? new ArrayList<>(Files.readAllLines(optionsFile, StandardCharsets.UTF_8))
@@ -32,13 +32,17 @@ class OptionsEditor {
 
             List<String> packs = index >= 0 ? parse(lines.get(index).substring(KEY.length())) : new ArrayList<>();
 
+            List<String> toAdd = new ArrayList<>();
             for (String name : names) {
-                if (packs.contains(name)) continue;
-                if (placement == ForceLoadMeta.Priority.TOP) {
-                    packs.add(name);
-                } else {
-                    packs.add(0, name);
+                if (!packs.contains(name)) {
+                    toAdd.add(name);
                 }
+            }
+
+            if (placement == ForceLoadMeta.Priority.TOP) {
+                packs.addAll(toAdd);
+            } else {
+                packs.addAll(0, toAdd);
             }
 
             String newLine = KEY + COMPACT.toJson(packs);
@@ -49,8 +53,10 @@ class OptionsEditor {
             }
 
             Files.write(optionsFile, lines, StandardCharsets.UTF_8);
+            return true;
         } catch (Exception e) {
             TXLoaderCore.LOGGER.error("Failed to update {}", optionsFile, e);
+            return false;
         }
     }
 
@@ -59,6 +65,7 @@ class OptionsEditor {
             List<String> parsed = COMPACT.fromJson(json.trim(), new TypeToken<List<String>>() {}.getType());
             return parsed != null ? new ArrayList<>(parsed) : new ArrayList<>();
         } catch (Exception e) {
+            TXLoaderCore.LOGGER.warn("Could not parse existing resourcePacks line, treating as empty: {}", json, e);
             return new ArrayList<>();
         }
     }

--- a/src/main/java/glowredman/txloader/PackMetaReader.java
+++ b/src/main/java/glowredman/txloader/PackMetaReader.java
@@ -1,6 +1,5 @@
 package glowredman.txloader;
 
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
@@ -22,16 +21,16 @@ class PackMetaReader {
             if (Files.isDirectory(pack)) {
                 Path meta = pack.resolve(META);
                 if (!Files.isRegularFile(meta)) return Optional.empty();
-                try (InputStream in = Files.newInputStream(meta)) {
-                    return parse(in);
+                try (Reader r = new InputStreamReader(Files.newInputStream(meta), StandardCharsets.UTF_8)) {
+                    return parse(r);
                 }
             }
             if (pack.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".zip")) {
                 try (ZipFile zip = new ZipFile(pack.toFile())) {
                     ZipEntry entry = zip.getEntry(META);
                     if (entry == null) return Optional.empty();
-                    try (InputStream in = zip.getInputStream(entry)) {
-                        return parse(in);
+                    try (Reader r = new InputStreamReader(zip.getInputStream(entry), StandardCharsets.UTF_8)) {
+                        return parse(r);
                     }
                 }
             }
@@ -42,8 +41,8 @@ class PackMetaReader {
         }
     }
 
-    private static Optional<ForceLoadMeta> parse(InputStream in) {
-        try (Reader r = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+    private static Optional<ForceLoadMeta> parse(Reader r) {
+        try {
             JsonObject root = TXLoaderCore.GSON.fromJson(r, JsonObject.class);
             if (root == null || !root.has("txloader") || !root.get("txloader").isJsonObject()) {
                 return Optional.empty();

--- a/src/main/java/glowredman/txloader/PackMetaReader.java
+++ b/src/main/java/glowredman/txloader/PackMetaReader.java
@@ -1,0 +1,60 @@
+package glowredman.txloader;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import com.google.gson.JsonObject;
+
+class PackMetaReader {
+
+    private static final String META = "pack.mcmeta";
+
+    static Optional<ForceLoadMeta> read(Path pack) {
+        try {
+            if (Files.isDirectory(pack)) {
+                Path meta = pack.resolve(META);
+                if (!Files.isRegularFile(meta)) return Optional.empty();
+                try (InputStream in = Files.newInputStream(meta)) {
+                    return parse(in);
+                }
+            }
+            if (pack.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".zip")) {
+                try (ZipFile zip = new ZipFile(pack.toFile())) {
+                    ZipEntry entry = zip.getEntry(META);
+                    if (entry == null) return Optional.empty();
+                    try (InputStream in = zip.getInputStream(entry)) {
+                        return parse(in);
+                    }
+                }
+            }
+            return Optional.empty();
+        } catch (Exception e) {
+            TXLoaderCore.LOGGER.warn("Failed to read pack.mcmeta of {}", pack, e);
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<ForceLoadMeta> parse(InputStream in) {
+        try (Reader r = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+            JsonObject root = TXLoaderCore.GSON.fromJson(r, JsonObject.class);
+            if (root == null || !root.has("txloader") || !root.get("txloader").isJsonObject()) {
+                return Optional.empty();
+            }
+            JsonObject tx = root.getAsJsonObject("txloader");
+            boolean force = tx.has("forceLoad") && tx.get("forceLoad").getAsBoolean();
+            String priority = tx.has("priority") ? tx.get("priority").getAsString() : null;
+            return Optional.of(new ForceLoadMeta(force, ForceLoadMeta.Priority.fromString(priority)));
+        } catch (Exception e) {
+            TXLoaderCore.LOGGER.warn("Failed to parse pack.mcmeta", e);
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/glowredman/txloader/TXLoaderCore.java
+++ b/src/main/java/glowredman/txloader/TXLoaderCore.java
@@ -83,6 +83,7 @@ public class TXLoaderCore implements IFMLLoadingPlugin {
         JarHandler.indexJars();
         ConfigHandler.load();
         ConfigHandler.moveRLAssets();
+        ForceLoadHandler.run(mcLocation, configDir);
     }
 
     @Override

--- a/src/test/java/glowredman/txloader/ForceLoadHandlerTest.java
+++ b/src/test/java/glowredman/txloader/ForceLoadHandlerTest.java
@@ -54,4 +54,25 @@ class ForceLoadHandlerTest {
         Path config = tmp.resolve("config");
         assertDoesNotThrow(() -> ForceLoadHandler.run(mc, config));
     }
+
+    @Test
+    void failedWriteIsNotRecordedAndRetries(@TempDir Path tmp) throws IOException {
+        Path mc = Files.createDirectories(tmp.resolve("mc"));
+        Path config = Files.createDirectories(tmp.resolve("config"));
+        Path packs = Files.createDirectories(mc.resolve("resourcepacks"));
+        makeFolderPack(packs, "ForcedPack", "{\"txloader\":{\"forceLoad\":true,\"priority\":\"top\"}}");
+
+        // Create options.txt as a directory so the write fails
+        Files.createDirectories(mc.resolve("options.txt"));
+
+        ForceLoadHandler.run(mc, config);
+
+        // The pack should NOT be recorded because the write failed
+        Path forceloaded = config.resolve("forceloaded.json");
+        if (Files.exists(forceloaded) && Files.isRegularFile(forceloaded)) {
+            ForceLoadState state = ForceLoadState.load(forceloaded);
+            assertFalse(state.contains("ForcedPack"), "Pack should not be recorded after a failed write");
+        }
+        // If forceloaded.json does not exist at all, that also satisfies the assertion
+    }
 }

--- a/src/test/java/glowredman/txloader/ForceLoadHandlerTest.java
+++ b/src/test/java/glowredman/txloader/ForceLoadHandlerTest.java
@@ -1,0 +1,57 @@
+package glowredman.txloader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ForceLoadHandlerTest {
+
+    private Path makeFolderPack(Path packsDir, String name, String mcmeta) throws IOException {
+        Path pack = Files.createDirectories(packsDir.resolve(name));
+        if (mcmeta != null) {
+            Files.write(pack.resolve("pack.mcmeta"), mcmeta.getBytes(StandardCharsets.UTF_8));
+        }
+        return pack;
+    }
+
+    private String packsLine(Path mc) throws IOException {
+        Path options = mc.resolve("options.txt");
+        if (!Files.exists(options)) return null;
+        return Files.readAllLines(options, StandardCharsets.UTF_8).stream().filter(l -> l.startsWith("resourcePacks:"))
+                .findFirst().orElse(null);
+    }
+
+    @Test
+    void enablesForcedPackOnceThenRespectsDisable(@TempDir Path tmp) throws IOException {
+        Path mc = Files.createDirectories(tmp.resolve("mc"));
+        Path config = Files.createDirectories(tmp.resolve("config"));
+        Path packs = Files.createDirectories(mc.resolve("resourcepacks"));
+        makeFolderPack(packs, "Forced", "{\"txloader\":{\"forceLoad\":true,\"priority\":\"top\"}}");
+        makeFolderPack(packs, "Plain", "{\"pack\":{\"pack_format\":1}}");
+
+        // First boot: enabled.
+        ForceLoadHandler.run(mc, config);
+        assertEquals("resourcePacks:[\"Forced\"]", packsLine(mc));
+        assertTrue(Files.exists(config.resolve("forceloaded.json")));
+
+        // User disables it.
+        Files.write(mc.resolve("options.txt"), "resourcePacks:[]\n".getBytes(StandardCharsets.UTF_8));
+
+        // Second boot: NOT re-enabled.
+        ForceLoadHandler.run(mc, config);
+        assertEquals("resourcePacks:[]", packsLine(mc));
+    }
+
+    @Test
+    void noResourcepacksDirIsSafe(@TempDir Path tmp) {
+        Path mc = tmp.resolve("mc");
+        Path config = tmp.resolve("config");
+        assertDoesNotThrow(() -> ForceLoadHandler.run(mc, config));
+    }
+}

--- a/src/test/java/glowredman/txloader/ForceLoadStateTest.java
+++ b/src/test/java/glowredman/txloader/ForceLoadStateTest.java
@@ -1,0 +1,46 @@
+package glowredman.txloader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ForceLoadStateTest {
+
+    @Test
+    void roundTripsRecords(@TempDir Path tmp) {
+        Path file = tmp.resolve("forceloaded.json");
+
+        ForceLoadState state = ForceLoadState.load(file);
+        assertFalse(state.contains("Pack.zip"));
+        state.record("Pack.zip", "2026-06-27T00:00:00Z");
+        state.save();
+
+        ForceLoadState reloaded = ForceLoadState.load(file);
+        assertTrue(reloaded.contains("Pack.zip"));
+    }
+
+    @Test
+    void emptyWhenFileMissing(@TempDir Path tmp) {
+        ForceLoadState state = ForceLoadState.load(tmp.resolve("nope.json"));
+        assertFalse(state.contains("anything"));
+    }
+
+    @Test
+    void emptyWhenFileCorrupt(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("forceloaded.json");
+        Files.write(file, "{not valid".getBytes(StandardCharsets.UTF_8));
+
+        ForceLoadState state = ForceLoadState.load(file);
+        assertFalse(state.contains("anything"));
+        // still usable
+        state.record("X", "t");
+        state.save();
+        assertTrue(ForceLoadState.load(file).contains("X"));
+    }
+}

--- a/src/test/java/glowredman/txloader/OptionsEditorTest.java
+++ b/src/test/java/glowredman/txloader/OptionsEditorTest.java
@@ -15,16 +15,16 @@ import org.junit.jupiter.api.io.TempDir;
 class OptionsEditorTest {
 
     private String packsLine(Path options) throws IOException {
-        return Files.readAllLines(options, StandardCharsets.UTF_8).stream()
-                .filter(l -> l.startsWith("resourcePacks:"))
+        return Files.readAllLines(options, StandardCharsets.UTF_8).stream().filter(l -> l.startsWith("resourcePacks:"))
                 .findFirst().orElse(null);
     }
 
     @Test
     void appendsTopToEnd(@TempDir Path tmp) throws IOException {
         Path options = tmp.resolve("options.txt");
-        Files.write(options, ("fov:1.0\nresourcePacks:[\"existing.zip\"]\nmipmapLevels:4\n")
-                .getBytes(StandardCharsets.UTF_8));
+        Files.write(
+                options,
+                ("fov:1.0\nresourcePacks:[\"existing.zip\"]\nmipmapLevels:4\n").getBytes(StandardCharsets.UTF_8));
 
         OptionsEditor.enable(options, Collections.singletonList("forced.zip"), ForceLoadMeta.Priority.TOP);
 

--- a/src/test/java/glowredman/txloader/OptionsEditorTest.java
+++ b/src/test/java/glowredman/txloader/OptionsEditorTest.java
@@ -83,4 +83,25 @@ class OptionsEditorTest {
 
         assertEquals("resourcePacks:[\"existing.zip\"]", packsLine(options));
     }
+
+    @Test
+    void multipleBottomNamesPreserveInputOrder(@TempDir Path tmp) throws IOException {
+        Path options = tmp.resolve("options.txt");
+        Files.write(options, "resourcePacks:[\"c\"]\n".getBytes(StandardCharsets.UTF_8));
+
+        OptionsEditor.enable(options, Arrays.asList("a", "b"), ForceLoadMeta.Priority.BOTTOM);
+
+        assertEquals("resourcePacks:[\"a\",\"b\",\"c\"]", packsLine(options));
+    }
+
+    @Test
+    void enableReturnsFalseWhenWriteFails(@TempDir Path tmp) throws IOException {
+        // Create options as a directory so Files.write throws
+        Path optionsDir = tmp.resolve("options.txt");
+        Files.createDirectories(optionsDir);
+
+        boolean result = OptionsEditor.enable(optionsDir, Collections.singletonList("x"), ForceLoadMeta.Priority.TOP);
+
+        assertFalse(result);
+    }
 }

--- a/src/test/java/glowredman/txloader/OptionsEditorTest.java
+++ b/src/test/java/glowredman/txloader/OptionsEditorTest.java
@@ -1,0 +1,86 @@
+package glowredman.txloader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class OptionsEditorTest {
+
+    private String packsLine(Path options) throws IOException {
+        return Files.readAllLines(options, StandardCharsets.UTF_8).stream()
+                .filter(l -> l.startsWith("resourcePacks:"))
+                .findFirst().orElse(null);
+    }
+
+    @Test
+    void appendsTopToEnd(@TempDir Path tmp) throws IOException {
+        Path options = tmp.resolve("options.txt");
+        Files.write(options, ("fov:1.0\nresourcePacks:[\"existing.zip\"]\nmipmapLevels:4\n")
+                .getBytes(StandardCharsets.UTF_8));
+
+        OptionsEditor.enable(options, Collections.singletonList("forced.zip"), ForceLoadMeta.Priority.TOP);
+
+        assertEquals("resourcePacks:[\"existing.zip\",\"forced.zip\"]", packsLine(options));
+        // other lines preserved
+        assertTrue(Files.readAllLines(options).contains("fov:1.0"));
+        assertTrue(Files.readAllLines(options).contains("mipmapLevels:4"));
+    }
+
+    @Test
+    void prependsBottomToStart(@TempDir Path tmp) throws IOException {
+        Path options = tmp.resolve("options.txt");
+        Files.write(options, "resourcePacks:[\"existing.zip\"]\n".getBytes(StandardCharsets.UTF_8));
+
+        OptionsEditor.enable(options, Collections.singletonList("forced.zip"), ForceLoadMeta.Priority.BOTTOM);
+
+        assertEquals("resourcePacks:[\"forced.zip\",\"existing.zip\"]", packsLine(options));
+    }
+
+    @Test
+    void doesNotDuplicate(@TempDir Path tmp) throws IOException {
+        Path options = tmp.resolve("options.txt");
+        Files.write(options, "resourcePacks:[\"forced.zip\"]\n".getBytes(StandardCharsets.UTF_8));
+
+        OptionsEditor.enable(options, Arrays.asList("forced.zip", "new.zip"), ForceLoadMeta.Priority.TOP);
+
+        assertEquals("resourcePacks:[\"forced.zip\",\"new.zip\"]", packsLine(options));
+    }
+
+    @Test
+    void addsLineWhenMissing(@TempDir Path tmp) throws IOException {
+        Path options = tmp.resolve("options.txt");
+        Files.write(options, "fov:1.0\n".getBytes(StandardCharsets.UTF_8));
+
+        OptionsEditor.enable(options, Collections.singletonList("forced.zip"), ForceLoadMeta.Priority.TOP);
+
+        assertEquals("resourcePacks:[\"forced.zip\"]", packsLine(options));
+        assertTrue(Files.readAllLines(options).contains("fov:1.0"));
+    }
+
+    @Test
+    void createsFileWhenMissing(@TempDir Path tmp) throws IOException {
+        Path options = tmp.resolve("options.txt");
+
+        OptionsEditor.enable(options, Collections.singletonList("forced.zip"), ForceLoadMeta.Priority.BOTTOM);
+
+        assertEquals("resourcePacks:[\"forced.zip\"]", packsLine(options));
+    }
+
+    @Test
+    void noOpOnEmptyNames(@TempDir Path tmp) throws IOException {
+        Path options = tmp.resolve("options.txt");
+        Files.write(options, "resourcePacks:[\"existing.zip\"]\n".getBytes(StandardCharsets.UTF_8));
+
+        OptionsEditor.enable(options, Collections.emptyList(), ForceLoadMeta.Priority.TOP);
+
+        assertEquals("resourcePacks:[\"existing.zip\"]", packsLine(options));
+    }
+}

--- a/src/test/java/glowredman/txloader/PackMetaReaderTest.java
+++ b/src/test/java/glowredman/txloader/PackMetaReaderTest.java
@@ -1,0 +1,71 @@
+package glowredman.txloader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PackMetaReaderTest {
+
+    private static final String FORCE_TOP =
+            "{\"pack\":{\"pack_format\":1},\"txloader\":{\"forceLoad\":true,\"priority\":\"top\"}}";
+
+    @Test
+    void readsFolderPack(@TempDir Path tmp) throws IOException {
+        Path pack = Files.createDirectory(tmp.resolve("FolderPack"));
+        Files.write(pack.resolve("pack.mcmeta"), FORCE_TOP.getBytes(StandardCharsets.UTF_8));
+
+        Optional<ForceLoadMeta> meta = PackMetaReader.read(pack);
+
+        assertTrue(meta.isPresent());
+        assertTrue(meta.get().forceLoad());
+        assertEquals(ForceLoadMeta.Priority.TOP, meta.get().priority());
+    }
+
+    @Test
+    void readsZipPackAndDefaultsPriorityToBottom(@TempDir Path tmp) throws IOException {
+        Path zip = tmp.resolve("ZipPack.zip");
+        try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(zip))) {
+            out.putNextEntry(new ZipEntry("pack.mcmeta"));
+            out.write("{\"txloader\":{\"forceLoad\":true}}".getBytes(StandardCharsets.UTF_8));
+            out.closeEntry();
+        }
+
+        Optional<ForceLoadMeta> meta = PackMetaReader.read(zip);
+
+        assertTrue(meta.isPresent());
+        assertTrue(meta.get().forceLoad());
+        assertEquals(ForceLoadMeta.Priority.BOTTOM, meta.get().priority());
+    }
+
+    @Test
+    void emptyWhenNoTxloaderSection(@TempDir Path tmp) throws IOException {
+        Path pack = Files.createDirectory(tmp.resolve("Plain"));
+        Files.write(pack.resolve("pack.mcmeta"), "{\"pack\":{\"pack_format\":1}}".getBytes(StandardCharsets.UTF_8));
+
+        assertFalse(PackMetaReader.read(pack).isPresent());
+    }
+
+    @Test
+    void emptyWhenMalformedJson(@TempDir Path tmp) throws IOException {
+        Path pack = Files.createDirectory(tmp.resolve("Broken"));
+        Files.write(pack.resolve("pack.mcmeta"), "{not json".getBytes(StandardCharsets.UTF_8));
+
+        assertFalse(PackMetaReader.read(pack).isPresent());
+    }
+
+    @Test
+    void emptyWhenNoMcmeta(@TempDir Path tmp) throws IOException {
+        Path pack = Files.createDirectory(tmp.resolve("NoMeta"));
+
+        assertFalse(PackMetaReader.read(pack).isPresent());
+    }
+}

--- a/src/test/java/glowredman/txloader/PackMetaReaderTest.java
+++ b/src/test/java/glowredman/txloader/PackMetaReaderTest.java
@@ -15,8 +15,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 class PackMetaReaderTest {
 
-    private static final String FORCE_TOP =
-            "{\"pack\":{\"pack_format\":1},\"txloader\":{\"forceLoad\":true,\"priority\":\"top\"}}";
+    private static final String FORCE_TOP = "{\"pack\":{\"pack_format\":1},\"txloader\":{\"forceLoad\":true,\"priority\":\"top\"}}";
 
     @Test
     void readsFolderPack(@TempDir Path tmp) throws IOException {

--- a/src/test/java/glowredman/txloader/PackMetaReaderTest.java
+++ b/src/test/java/glowredman/txloader/PackMetaReaderTest.java
@@ -68,4 +68,23 @@ class PackMetaReaderTest {
 
         assertFalse(PackMetaReader.read(pack).isPresent());
     }
+
+    @Test
+    void emptyWhenZipHasNoMcmeta(@TempDir Path tmp) throws IOException {
+        Path zip = tmp.resolve("Empty.zip");
+        try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(zip))) {
+            out.putNextEntry(new ZipEntry("other.txt"));
+            out.write("x".getBytes(StandardCharsets.UTF_8));
+            out.closeEntry();
+        }
+        assertFalse(PackMetaReader.read(zip).isPresent());
+    }
+
+    @Test
+    void priorityFromStringIsCaseInsensitiveAndDefaultsBottom() {
+        assertEquals(ForceLoadMeta.Priority.TOP, ForceLoadMeta.Priority.fromString("top"));
+        assertEquals(ForceLoadMeta.Priority.TOP, ForceLoadMeta.Priority.fromString("TOP"));
+        assertEquals(ForceLoadMeta.Priority.BOTTOM, ForceLoadMeta.Priority.fromString(null));
+        assertEquals(ForceLoadMeta.Priority.BOTTOM, ForceLoadMeta.Priority.fromString("other"));
+    }
 }


### PR DESCRIPTION
Packs in resourcepacks/ can opt into auto-enabling on first boot via a txloader block in pack.mcmeta (forceLoad + priority top/bottom).
Enabled once, recorded in config/txloader/forceloaded.json. Player can then disable it permanently.
Edits options.txt before it is loaded

Verified in a real client.

Mainly going to be used for the GuideNH guides